### PR TITLE
Enable experimental jsonnet features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ name = "rjsonnet"
 crate-type = ["cdylib"]
 
 [dependencies]
-jrsonnet-evaluator = { git = "https://github.com/CertainLach/jrsonnet.git" }
+jrsonnet-evaluator = { git = "https://github.com/CertainLach/jrsonnet.git", features = ["exp-preserve-order", "exp-destruct", "exp-object-iteration"] }
 jrsonnet-parser = { git = "https://github.com/CertainLach/jrsonnet.git" }
-jrsonnet-stdlib = { git = "https://github.com/CertainLach/jrsonnet.git" }
+jrsonnet-stdlib = { git = "https://github.com/CertainLach/jrsonnet.git", features = ["exp-preserve-order"] }
 jrsonnet-gcmodule = "0.3.5"
 pyo3 = { version = "0.18.0", features = ["abi3-py37", "extension-module"] }

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Keyword arguments to these functions are used to control the virtual machine. Th
 * `max_stack`   (number)
 * `gc_min_objects`   (number, ignored)
 * `gc_growth_trigger`   (number, ignored)
-* `ext_vars`   (dict: string to string)
-* `ext_codes`   (dict string to string)
-* `tla_vars`   (dict string to string)
-* `tla_codes`   (dict string to string)
+* `ext_vars`   (dict, string to string)
+* `ext_codes`   (dict, string to string)
+* `tla_vars`   (dict, string to string)
+* `tla_codes`   (dict, string to string)
 * `max_trace`   (number)
 * `import_callback`   (see example in [tests/](./tests/))
 * `native_callbacks`   (see example in [tests/](./tests/))
+* `preserve_order`   (bool, preserve object field order during manifestification)
 
 The argument `import_callback` can be used to pass a callable, to trap the Jsonnet `import` and `importstr` constructs.
 This allows, e.g., reading files out of archives or implementing library search paths.


### PR DESCRIPTION
* `exp-destruct`: Destructuring assignment
* `exp-preserve-order`: Object field order preservation during manifestification
* `exp-object-iteration`: Iteration over object fields in comprehensions

See https://github.com/CertainLach/jrsonnet/blob/153383ce07c147314f7250b7a9673599e5bb7c4f/docs/features.md#features