### PR TITLE
Respect preserve_order in evaluate_file and evaluate_snippet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,10 +294,12 @@ impl VirtualMachine {
             );
         }
 
+        let manifest_format = JsonFormat::cli(4, preserve_order);
+
         state.settings_mut().context_initializer = tb!(context_initializer);
         Ok(Self {
             state,
-            manifest_format: Box::new(JsonFormat::default()),
+            manifest_format: Box::new(manifest_format),
             trace_format: Box::new(trace_format),
             tla_args,
         })

--- a/tests/test_rjsonnet.py
+++ b/tests/test_rjsonnet.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -106,3 +107,10 @@ def test_import_callback_error():
             import_callback=import_callback_2,
             native_callbacks=native_callbacks,
         )
+
+def test_preserve_order():
+    code = "{c: 1, a: 2, b: 3}"
+    json_str = rjsonnet.evaluate_snippet("test", code, preserve_order=True)
+    # as of python 3.6 dicts are ordered, and the json 
+    obj = json.loads(json_str)
+    assert list(obj) == ['c', 'a', 'b']


### PR DESCRIPTION
Currently, `preserve_order` has no effect when passed to `rjsonnet.evaluate_file` or `rjsonnet.evaluate_snippet`.

Judging from the implementation [in jrsonnet-cli](https://github.com/CertainLach/jrsonnet/blob/master/crates/jrsonnet-cli/src/manifest.rs), it looks like the `preserve_order` field needs to be set on the `JsonFormat` that is passed in to the eventual call to `val.manifest()`

Unfortunately this field is private, so it can't be modified directly. However, `JsonFormat::cli()` accepts an argument for `preserve_order`, and uses the same values as `::default()` for everything that it _doesn't_ allow you to specify, so this is a workable solution for getting the preserve-order behavior to work.

The downside is that if `JsonFormat::cli()` ever changes, it could affect the output of `rjsonnet.evaluate_file/snippet`. It doesn't seem terribly likely that this will be a problem, but I thought I'd mention it in the interest of full disclosure.

I also added a test for this behavior, I think I did it right but I'm not super familiar with `pytest` so feel free to change it if necessary!