### PR TITLE
Fix type conversion for negative integers returned from native functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ fn pyobject_to_val(py: Python, obj: PyObject) -> PyResult<Val> {
         Ok(Val::Bool(b.is_true()))
     } else if let Ok(f) = obj.downcast_bound::<PyFloat>(py) {
         Ok(Val::Num(f.value() as _))
-    } else if let Ok(l) = obj.extract::<u64>(py) {
+    } else if let Ok(l) = obj.extract::<i64>(py) {
         Ok(Val::Num(l as _))
     } else if obj.is_none(py) {
         Ok(Val::Null)

--- a/tests/test.jsonnet
+++ b/tests/test.jsonnet
@@ -1,5 +1,5 @@
 std.assertEqual(({ x: 1, y: self.x } { x: 2 }).y, 2) &&
 std.assertEqual(std.native("concat")("foo", "bar"), "foobar") &&
-std.assertEqual(std.native("return_types")(), {a: [1, 2, 3, null, []], b: 1, c: true, d: null, e: {x: 1, y: 2, z: ["foo"]}}) &&
+std.assertEqual(std.native("return_types")(), {a: [1, 2, 3, null, []], b: 1, c: true, d: null, e: {x: 1, y: 2, z: ["foo"]}, f: [-1, -1.0]}) &&
 true
 

--- a/tests/test_rjsonnet.py
+++ b/tests/test_rjsonnet.py
@@ -24,6 +24,7 @@ def return_types():
         "c": True,
         "d": None,
         "e": {"x": 1, "y": 2, "z": ["foo"]},
+        "f": [-1, -1.0],
     }
 
 


### PR DESCRIPTION
Currently integers are typed as u64 which means that negative integers cause rjsonnet to fail with: 
`RuntimeError: runtime error: error invoking native extension return_types: TypeError: Unrecognized type return from Python Jsonnet native extension.`

Fix by using i64 instead and add a couple tests.