### PR TITLE
Fix native_callbacks type hint

### DIFF
--- a/rjsonnet.pyi
+++ b/rjsonnet.pyi
@@ -13,7 +13,7 @@ def evaluate_file(
     tla_codes: Dict[str, str] = {},
     max_trace: int = 20,
     import_callback: Optional[Callable[[str, str], Tuple[str, Optional[str]]]] = None,
-    native_callbacks: Dict[str, Tuple[str, Callable]] = {},
+    native_callbacks: Dict[str, Tuple[Tuple[str, ...], Callable]] = {},
     preserve_order: bool = False,
 ) -> str: ...
 
@@ -31,6 +31,6 @@ def evaluate_snippet(
     tla_codes: Dict[str, str] = {},
     max_trace: int = 20,
     import_callback: Optional[Callable[[str, str], Tuple[str, Optional[str]]]] = None,
-    native_callbacks: Dict[str, Tuple[str, Callable]] = {},
+    native_callbacks: Dict[str, Tuple[Tuple[str, ...], Callable]] = {},
     preserve_order: bool = False,
 ) -> str: ...


### PR DESCRIPTION
The native callbacks argument maps callback names to their parameter names and the corresponding Python callable. The parameter names should be a tuple of strings.

The rust implementation expects this as a [tuple](https://github.com/Rayshard/rjsonnet-py/blob/de694e59607ee14d02dfbc3ac6e0faef2be698cc/src/lib.rs#L281).